### PR TITLE
KernelConfig: Provide all DTBs to AOSP for inclusion in vendor_boot

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -16,7 +16,14 @@ BUILD_KERNEL := false
 
 ifeq ($(BUILD_KERNEL),false)
 
-LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel-dtb-$(TARGET_DEVICE)
+ifeq ($(BOARD_INCLUDE_DTB_IN_BOOTIMG), true)
+    # AOSP will concatenate all these into a single dtb.img
+    BOARD_PREBUILT_DTBIMAGE_DIR := $(KERNEL_PATH)/common-kernel/$(TARGET_DEVICE)/
+else
+    dtb := "-dtb"
+endif
+
+LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel$(dtb)-$(TARGET_DEVICE)
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_KERNEL):kernel

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -17,10 +17,11 @@ for platform in $PLATFORMS; do \
 
     case $platform in
         sagami)
-            DEVICE=$SAGAMI;
-            COMPRESSED="false";
-            APENDED_DTB="false";
-            DTBO="true";;
+            DEVICE=$SAGAMI
+            COMPRESSED="false"
+            APENDED_DTB="false"
+            DTBO="true"
+            ;;
     esac
 
     if [ $COMPRESSED = "true" ]; then

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -1,8 +1,8 @@
 set -e
 # Check if mkdtimg tool exist
-[[ ! -f "$MKDTIMG" ]] && MKDTIMG="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
-[[ ! -f "$MKDTIMG" ]] && MKDTIMG="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
-[[ ! -f "$MKDTIMG" ]] && (echo "No mkdtbo script/executable found"; exit 1)
+[ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
+[ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
+[ ! -f "$MKDTIMG" ] && (echo "No mkdtbo script/executable found"; exit 1)
 
 
 cd "$KERNEL_TOP"/kernel


### PR DESCRIPTION
Aosp will concatenate all dtb files found in BOARD_PREBUILT_DTBIMAGE_DIR, hence they are now copied into a single subfolder for easy inclusion.  Since these dtbs are supposed to be identical per SoC/board/platform we will later optimize the build process to only build the dtb (and kernel) once per platform, but for now - erring on the side of caution - store them per-device.

These dtb files allow a more-or-less generic kernel to reside in the bootimage.  Everything here is SoC specific, and all platform/device specific customization and finalization resides in the DTBO as per usual nowadays.
