### PR TITLE
[WIP]build_shared_vars.sh: Add murray platform to the buildable list

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -22,6 +22,12 @@ for platform in $PLATFORMS; do \
             APENDED_DTB="false"
             DTBO="true"
             ;;
+        murray)
+            DEVICE=$MURRAY
+            COMPRESSED="false"
+            APENDED_DTB="false"
+            DTBO="true"
+            ;;
     esac
 
     if [ $COMPRESSED = "true" ]; then

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -43,8 +43,9 @@ else
 fi
 
 SAGAMI="pdx214 pdx215"
+MURRAY="pdx225"
 
-PLATFORMS="sagami"
+PLATFORMS="sagami murray"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg


### PR DESCRIPTION
Xperia 10IV (PDX225) is Murray platform and with  the recent addition of the support for this platform
we need to be able to build a kernel for it.

(This should not be merged until kernel is in OK state for Murray as to reduce the chance of possibly breaking devices)